### PR TITLE
Use onpointerdown instead of onclick for mining.

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 			<div id="sectionCash">
 				<p>You have <span id="cash">$0</span></p>
 			</div>
-			<div id="oreIcon" onclick="mineOre()"></div>
+			<div id="oreIcon" onpointerdown="mineOre()"></div>
 			<p id="oreName">Sand</p>
 			<p id="oreInfo">Ore value: <span id="currentOreValue" style="color: #8f8">$1</span><br>Hit points: <span id="currentHitPoints" style="color: #8ff">10</span><br>Hardness: <span id="currentHardness" style="color: #fb8">0</span><br>Damage: <span id="currentDamage">0</span></p>
 			<div class="arrow" id="arrowLeft" onclick="previousOre()"></div>


### PR DESCRIPTION
onclick doesn't handle multitouch interactions well, dropping taps if they happen to overlap, which makes the game feel unresponsive. onpointerdown, on the otherhand, will record every tap event regardless of ordering.

Tested on both web and Android.